### PR TITLE
always refetch verison.manifest unless pinned

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,14 @@ $ ls -la src/
 ```
 
 You can find the contents of your current version.manifest in `src/build/version.manifest` after the script has been ran once.
+
+
+## Running edge or stable builds
+By default, this script will run on stable releases of Armory.
+Edge builds are internal Armory builds that require access to our Jenkins.
+Try running the script, if you get an error reaching jenkins, [go here](https://github.com/armory-io/command#configuration) then rerun.
+
+For more info, see:
+```bash
+./src/install.sh --help
+```

--- a/README.md
+++ b/README.md
@@ -29,3 +29,20 @@ watch -n 1  'kubectl -n $(myLatestCreatedNamespace) get pods'
 # keep an eye out on 
 watch -n 1 'kubectl -n $(myLatestCreatedNamespace) logs -l app=dinghy'
 ```
+
+
+## Pinning versions
+By default, we're always going to be fetching `stable` Armory versions. If you want to pin it to a specific version,
+you'll need to add it to src/version.manifest. 
+Example: 
+```bash
+$ ls -la src/
+ $ ls -la src/
+ drwxr-xr-x 10 kevinawoo staff   320 May 11 15:22 ./
+ drwxr-xr-x 13 kevinawoo staff   416 May 11 15:25 ../
+ -rwxr-xr-x  1 kevinawoo staff 44939 May 11 15:22 install.sh*
+ -rw-r--r--  1 kevinawoo staff  1457 May 11 14:01 version.manifest  <--- this is a pinned version.manifest
+ ...
+```
+
+You can find the contents of your current version.manifest in `src/build/version.manifest` after the script has been ran once.

--- a/src/install.sh
+++ b/src/install.sh
@@ -53,16 +53,18 @@ function fetch_latest_version_manifest() {
   mkdir -p build
 
   echo
-  if [[ ${FETCH_LATEST_EDGE_VERSION} == true ]]; then
-    echo "Fetching edge version of src/version.manifest..."
+  if [[ -f "version.manifest" ]]; then
+    echo "Using pinned versions found in src/version.manifests!"
+    cp version.manifest build/version.manifest
+  elif [[ ${FETCH_LATEST_EDGE_VERSION} == true ]]; then
+    echo "Fetching edge version to src/build/version.manifest..."
     ../bin/fetch-latest-armory-version.sh
-    echo "Pinned the latest edge version in src/version.manifest!"
-  elif [[ ! -f "version.manifest" || ${FETCH_LATEST_STABLE_VERSION} == true ]]; then
-    echo "Fetching latest stable src/version.manifest..."
+  else # we're going to fetch stable by default  ${FETCH_LATEST_STABLE_VERSION} == true
+    echo "Fetching latest stable to src/build/version.manifest..."
     curl -sS "https://s3-us-west-2.amazonaws.com/armory-web/install/release/armoryspinnaker-latest-version.manifest" > build/armoryspinnaker-latest-version.manifest
     source build/armoryspinnaker-latest-version.manifest
 
-cat <<EOF > version.manifest
+cat <<EOF > build/version.manifest
 ## INFO: this file has been created as an untracked file so that the installer can run idempotently with pinned versions below.
 ## Committing this file means you'll be pinning the installer with the versions listed below.
 ##
@@ -71,11 +73,7 @@ cat <<EOF > version.manifest
 
 EOF
 
-      curl -sS "${armoryspinnaker_version_manifest_url}" >> version.manifest
-
-      echo "Pinned the latest stable version in src/version.manifest!"
-  else
-    echo "Using pinned versions found in src/version.manifests!"
+    curl -sS "${armoryspinnaker_version_manifest_url}" >> build/version.manifest
   fi
 }
 
@@ -1273,7 +1271,7 @@ done
 
 
 fetch_latest_version_manifest
-source version.manifest
+source build/version.manifest
 
 function main() {
   continue_env


### PR DESCRIPTION
Build scripts shouldn't change the working tree. We're also going to fetch from the latest edge or stable. If you want to pin the version.manifest, you'll need to do some work. Checkout the readme.

- add docs on edge/stable
- add info on pinning version.manifest
- always refetch verison.manifest unless pinned

 